### PR TITLE
docs: 更新快速开始 / 本地开发步骤

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,20 @@ cd compoder
 pnpm install
 ```
 
-**3. Environment Variables & Configuration Files**
+**3. Start Docker Container**
+
+```bash
+# Docker configuration
+cp docker-compose.template.yml docker-compose.yml
+
+# For local development, mainly used to start MongoDB database
+docker compose up -d
+
+# or
+docker-compose up -d
+```
+
+**4. Environment Variables & Configuration Files**
 
 ```bash
 # Fill in the corresponding environment variables
@@ -120,16 +133,6 @@ cp data/config.template.json data/config.json
 # Codegen configuration initialization
 cp data/codegens.template.json data/codegens.json
 pnpm migrate-codegen
-
-# Docker configuration
-cp docker-compose.template.yml docker-compose.yml
-```
-
-**4. Start Docker Container**
-
-```bash
-# For local development, mainly used to start MongoDB database
-docker-compose up -d
 ```
 
 **5. Start Storybook Business Component Documentation**

--- a/README_CN.md
+++ b/README_CN.md
@@ -108,7 +108,20 @@ cd compoder
 pnpm install
 ```
 
-**3. 环境变量 & 配置文件**
+**3. 启动 Docker 容器**
+
+```bash
+# docker 配置
+cp docker-compose.template.yml docker-compose.yml
+
+# 本地开发下，主要用来启动 MongoDB 数据库
+docker compose up -d
+
+# or
+docker-compose up -d
+```
+
+**4. 环境变量 & 配置文件**
 
 ```bash
 # 填写对应的环境变量
@@ -120,16 +133,6 @@ cp data/config.template.json data/config.json
 # Codegen 配置初始化
 cp data/codegens.template.json data/codegens.json
 pnpm migrate-codegen
-
-# docker 配置
-cp docker-compose.template.yml docker-compose.yml
-```
-
-**4. 启动 Docker 容器**
-
-```bash
-# 本地开发下，主要用来启动 MongoDB 数据库
-docker-compose up -d
 ```
 
 **5. 启动 Storybook 业务组件文档**


### PR DESCRIPTION
从实际测试来看 
执行 `pnpm migrate-codegen` 需要依赖 docker 容器中的服务