### PR TITLE
fix: 修复组件生成代码时JSON解析报错问题，并将注释翻译为英文

### DIFF
--- a/app/api/ai-core/steps/design-component/utils.ts
+++ b/app/api/ai-core/steps/design-component/utils.ts
@@ -234,20 +234,20 @@ export async function generateComponentDesign(
       // Fix backticks in the JSON string by replacing them with escaped double quotes
       let jsonString = jsonMatch[0]
 
-      // 1. 先处理已经存在的转义字符
+      // 1. Handle existing escape characters first
       jsonString = jsonString.replace(/\\`/g, "\\\\`")
 
-      // 2. 处理反引号包裹的内容
+      // 2. Process content wrapped in backticks
       jsonString = jsonString.replace(
-        /`((?:[^`\\]|\\.|\\`)*)`/g, // 更精确的正则表达式
+        /`((?:[^`\\]|\\.|\\`)*)`/g, // More precise regular expression
         function (match, content) {
-          // 处理特殊字符
+          // Handle special characters
           const escaped = content
-            .replace(/\\/g, "\\\\") // 先处理反斜杠
-            .replace(/"/g, '\\"') // 处理双引号
-            .replace(/\n/g, "\\n") // 处理换行
-            .replace(/\r/g, "\\r") // 处理回车
-            .replace(/\t/g, "\\t") // 处理制表符
+            .replace(/\\/g, "\\\\") // Handle backslashes first
+            .replace(/"/g, '\\"') // Handle double quotes
+            .replace(/\n/g, "\\n") // Handle newlines
+            .replace(/\r/g, "\\r") // Handle carriage returns
+            .replace(/\t/g, "\\t") // Handle tabs
           return `"${escaped}"`
         },
       )

--- a/app/api/ai-core/steps/design-component/utils.ts
+++ b/app/api/ai-core/steps/design-component/utils.ts
@@ -233,12 +233,21 @@ export async function generateComponentDesign(
 
       // Fix backticks in the JSON string by replacing them with escaped double quotes
       let jsonString = jsonMatch[0]
-      // Replace backtick-enclosed blocks with properly escaped JSON strings
+
+      // 1. 先处理已经存在的转义字符
+      jsonString = jsonString.replace(/\\`/g, "\\\\`")
+
+      // 2. 处理反引号包裹的内容
       jsonString = jsonString.replace(
-        /`([\s\S]*?)`/g,
+        /`((?:[^`\\]|\\.|\\`)*)`/g, // 更精确的正则表达式
         function (match, content) {
-          // Escape any double quotes and newlines in the content
-          const escaped = content.replace(/"/g, '\\"').replace(/\n/g, "\\n")
+          // 处理特殊字符
+          const escaped = content
+            .replace(/\\/g, "\\\\") // 先处理反斜杠
+            .replace(/"/g, '\\"') // 处理双引号
+            .replace(/\n/g, "\\n") // 处理换行
+            .replace(/\r/g, "\\r") // 处理回车
+            .replace(/\t/g, "\\t") // 处理制表符
           return `"${escaped}"`
         },
       )


### PR DESCRIPTION
BUG描述：组件生成代码时，JSON数据解析报错
<img width="401" alt="微信图片_20250325205151" src="https://github.com/user-attachments/assets/00936663-606e-4064-b823-32aaf820588f" />