### PR TITLE
fix: 处理不支持 视觉（图片）的模型（如 deepseek v3 chat）

### DIFF
--- a/app/commons/LLMSelectorProvider/useLLMOptions.ts
+++ b/app/commons/LLMSelectorProvider/useLLMOptions.ts
@@ -1,20 +1,10 @@
 import { useEffect, useState } from "react"
-import { AIProvider } from "@/lib/config/ai-providers"
+import { AIProvider, AIProviderConfig } from "@/lib/config/ai-providers"
 import { LLMOption } from "@/components/biz/LLMSelector/interface"
 
 // Define a new interface for API response which matches the return from the API
 interface ConfigApiResponse {
-  providers: Record<
-    AIProvider,
-    {
-      provider: AIProvider
-      models: Array<{
-        model: string
-        title: string
-        apiKey: string
-      }>
-    }
-  >
+  providers: Record<AIProvider, AIProviderConfig>
 }
 
 /**
@@ -51,6 +41,7 @@ export function useLLMOptions() {
                 provider,
                 modelId: model.model,
                 title: model.title,
+                features: model.features,
               })
             })
           },

--- a/components/biz/LLMSelector/interface.ts
+++ b/components/biz/LLMSelector/interface.ts
@@ -4,6 +4,7 @@ export interface LLMOption {
   provider: AIProvider
   modelId: string
   title: string
+  features: Array<"vision">
 }
 
 export interface LLMSelectorProps {

--- a/data/config.template.json
+++ b/data/config.template.json
@@ -7,24 +7,28 @@
                     "model": "anthropic/claude-3.7-sonnet",
                     "title": "Claude 3.7 Sonnet (OpenRouter)",
                     "baseURL": "https://openrouter.ai/api/v1",
+                    "features": ["vision"],
                     "apiKey": "sk-****"
                 },
                 {
                     "model": "anthropic/claude-3.5-sonnet",
                     "title": "Claude 3.5 Sonnet (OpenRouter)",
                     "baseURL": "https://openrouter.ai/api/v1",
+                    "features": ["vision"],
                     "apiKey": "sk-****"
                 },
                 {
                     "model": "openai/gpt-4o",
                     "title": "GPT-4o (OpenRouter)",
                     "baseURL": "https://openrouter.ai/api/v1",
+                    "features": ["vision"],
                     "apiKey": "sk-****"
                 },
                 {
                     "model": "gpt-4o",
                     "title": "GPT-4o (302)",
                     "baseURL": "https://api.302.ai/v1",
+                    "features": ["vision"],
                     "apiKey": "sk-****"
                 }
             ]
@@ -36,12 +40,14 @@
                     "model": "claude-3-7-sonnet-latest",
                     "title": "Claude 3.7 Sonnet (302)",
                     "baseURL": "https://api.302.ai/v1",
+                    "features": ["vision"],
                     "apiKey": "sk-****"
                 },
                 {
                     "model": "claude-3-5-sonnet-latest",
                     "title": "Claude 3.5 Sonnet (302)",
                     "baseURL": "https://api.302.ai/v1",
+                    "features": ["vision"],
                     "apiKey": "sk-****"
                 }
             ]
@@ -53,6 +59,7 @@
                     "model": "deepseek-chat",
                     "title": "DeepSeek-V3 Chat (DeepSeek)",
                     "baseURL": "https://api.deepseek.com/v1",
+                    "features": [],
                     "apiKey": "sk-****"
                 }
             ]
@@ -64,6 +71,7 @@
                     "model": "qwen2.5:14b",
                     "title": "qwen2.5 (Ollama)",
                     "baseURL": "http://localhost:11434/api",
+                    "features": ["vision"],
                     "apiKey": ""
                 }
             ]

--- a/lib/config/ai-providers.ts
+++ b/lib/config/ai-providers.ts
@@ -9,6 +9,7 @@ export type AIModelConfig = {
   model: string
   title: string
   baseURL: string
+  features: Array<"vision">
   apiKey: string
 }
 


### PR DESCRIPTION
关联 issue 链接：https://github.com/IamLiuLv/compoder/issues/13

变更说明：
1. 首先，在模型配置文件 data/config.template.json 中，为每个 model 增加 features 字段，如果模型支持 视觉，为其配置 "vision" 选项。

```diff
# 支持视觉
{
  "model": "claude-3-5-sonnet-latest",
  "title": "Claude 3.5 Sonnet (302)",
  "baseURL": "https://api.302.ai/v1",
+ "features": ["vision"],
  "apiKey": "sk-bUI5GLOewMp8hyNCBCljnjkMysFLdxPFtprO6UyMlm2VXvnR"
}

# 不支持视觉
{
  "model": "deepseek-chat",
  "title": "DeepSeek-V3 Chat (DeepSeek)",
  "baseURL": "https://api.deepseek.com/v1",
+ "features": [],
  "apiKey": "sk-60237b5024b4438f858ec4f7c7946c9b"
}
```

2. 在获取到 model config 并添加到 LLMOptions 时，将 features 配置也保存其中：
```diff
// /app/commons/LLMSelectorProvider/useLLMOptions.ts
providerConfig.models.forEach(model => {
  llmOptions.push({
    provider,
    modelId: model.model,
    title: model.title,
+   features: model.features,
  })
})
```

3. 在使用 ChatInput 容器时，若当前模型不支持视觉：（含 codegen/page 和 codegen/component/page 两个场景）
- 屏蔽 Draw UI 入口 和 已添加的 Image preview area；
- 在发送 ASK 问答前，取消 images 数据的上报。
```tsx
const modelConfig = useMemo(() => {
  return options.find(opt => opt.modelId === model)
}, [model, options])
// 支持视觉
const supportVision = modelConfig?.features.includes("vision")

// 在发送 ASK 问答前，取消 images 数据的上报
const prompt: Prompt[] = [
  ...(supportVision && images.length > 0
    ? images.map(image => ({ type: "image" as const, image }))
    : []),
  {
    type: "text" as const,
    text: input || chatInput,
  },
]

// 屏蔽 Draw UI 入口 和 已添加的 Image preview area
<ChatInput 
  actions={[supportVision && (Draw UI 入口), ...].filter(Boolean)} 
  images={supportVision ? images : []}
  ... />
```