### PR TITLE
feat: 添加 AppSidebarLayout 侧边栏布局组件及其故事示例

### DIFF
--- a/components/biz/AppSidebarLayout/AppSidebarLayout.feature
+++ b/components/biz/AppSidebarLayout/AppSidebarLayout.feature
@@ -1,0 +1,36 @@
+Feature: AppSidebarLayout 侧边栏布局组件
+  作为一名用户
+  我希望 AppSidebarLayout 能在不同场景下正确渲染
+  以便获得良好的导航与交互体验
+
+  Scenario: 菜单为空
+    Given 用户已登录
+    And 侧边栏菜单为空
+    When 页面加载
+    Then 应显示无菜单项的侧边栏
+    And 主内容区正常展示
+
+  Scenario: 仅有一个菜单项
+    Given 用户已登录
+    And 侧边栏仅有一个菜单项
+    When 页面加载
+    Then 应正确显示该唯一菜单项
+    And 主内容区正常展示
+
+  Scenario: 主题切换（深色模式）
+    Given 用户已登录
+    And 侧边栏有多个菜单项
+    When 切换为深色主题
+    Then 侧边栏与主内容区应以深色风格展示
+
+  Scenario: 加载中状态
+    Given 用户已登录
+    And 侧边栏有多个菜单项
+    When 页面处于加载中
+    Then 主内容区应显示"加载中..."提示
+
+  Scenario: 错误状态
+    Given 用户已登录
+    And 侧边栏有多个菜单项
+    When 页面加载失败
+    Then 主内容区应显示"加载失败，请重试。"提示 

--- a/components/biz/AppSidebarLayout/AppSidebarLayout.stories.tsx
+++ b/components/biz/AppSidebarLayout/AppSidebarLayout.stories.tsx
@@ -126,3 +126,63 @@ export const WithSettingsActive: Story = {
     },
   },
 }
+
+export const EmptyMenu: Story = {
+  render: () => (
+    <StoryWrapper navMain={[]} user={mockData.user}>
+      <ExampleContent />
+    </StoryWrapper>
+  ),
+  name: "Empty Menu",
+}
+
+export const SingleMenuItem: Story = {
+  render: () => (
+    <StoryWrapper navMain={[mockData.navMain[0]]} user={mockData.user}>
+      <ExampleContent />
+    </StoryWrapper>
+  ),
+  name: "Single Menu Item",
+}
+
+export const ThemeSwitch: Story = {
+  render: () => (
+    <div className="dark bg-zinc-900 min-h-screen">
+      <StoryWrapper navMain={mockData.navMain} user={mockData.user}>
+        <ExampleContent />
+      </StoryWrapper>
+    </div>
+  ),
+  parameters: {
+    backgrounds: {
+      default: "dark",
+      values: [
+        { name: "light", value: "#ffffff" },
+        { name: "dark", value: "#18181b" },
+      ],
+    },
+  },
+  name: "Theme Switch (Dark)",
+}
+
+export const LoadingState: Story = {
+  render: () => (
+    <StoryWrapper navMain={mockData.navMain} user={mockData.user}>
+      <div className="flex items-center justify-center h-96 text-xl text-muted-foreground">
+        Loading...
+      </div>
+    </StoryWrapper>
+  ),
+  name: "Loading State",
+}
+
+export const ErrorState: Story = {
+  render: () => (
+    <StoryWrapper navMain={mockData.navMain} user={mockData.user}>
+      <div className="flex items-center justify-center h-96 text-xl text-destructive">
+        Loading failed, please try again.
+      </div>
+    </StoryWrapper>
+  ),
+  name: "Error State",
+}


### PR DESCRIPTION
- 新增 AppSidebarLayout 组件的功能测试用例，涵盖不同场景下的渲染情况。
- 在故事书中添加多个故事示例，包括空菜单、单个菜单项、主题切换、加载状态和错误状态，以展示组件的不同表现。