### PR TITLE
fix: storybook doc chat-input component 使初始填充内容生效

### DIFF
--- a/components/biz/ChatInput/ChatInput.stories.tsx
+++ b/components/biz/ChatInput/ChatInput.stories.tsx
@@ -26,10 +26,11 @@ export default {
 
 // Basic template
 const Template: StoryFn<typeof ChatInput> = args => {
-  const [value, setValue] = useState("")
+  const { value: defaultValue, ...rest } = args
+  const [value, setValue] = useState(defaultValue || "")
   return (
     <ChatInput
-      {...args}
+      {...rest}
       value={value}
       onChange={val => {
         console.log("val", val)


### PR DESCRIPTION
代码改动：
```diff
// components/biz/ChatInput/ChatInput.stories.tsx
// Basic template
const Template: StoryFn<typeof ChatInput> = args => {
+ const { value: defaultValue, ...rest } = args
+ const [value, setValue] = useState(defaultValue || "")
  return (
    <ChatInput
+     {...rest}
      value={value}
      onChange={val => {
        console.log("val", val)
        setValue(val)
      }}
      onSubmit={() => console.log("submitted:", value)}
    />
  )
}
```

修改前效果：
<img width="1028" alt="image" src="https://github.com/user-attachments/assets/b4ccbe26-467b-4252-a6fc-f2bc363a4c5a" />

修改后效果：
<img width="1027" alt="image" src="https://github.com/user-attachments/assets/b7f1da0c-3408-424a-ac80-cc1a2fb15f37" />


