### PR TITLE
pref: 首次生成 Component code 时，Generator 阶段取消不必要的 messages 上下文

### DIFF
--- a/app/api/ai-core/steps/generate-component/utils.ts
+++ b/app/api/ai-core/steps/generate-component/utils.ts
@@ -118,7 +118,7 @@ export const buildSystemPrompt = (
 export const buildCurrentComponentMessage = (
   component: WorkflowContext["query"]["component"],
 ): Array<CoreMessage> => {
-  return component
+  return component && !component.isInitialized
     ? [
         {
           role: "user",


### PR DESCRIPTION
问题描述：
在首次生成 Component code 时，由于没有上下文消息，`buildCurrentComponentMessage()` 构建上下文信息会携带一对无意义的 `messages: [{ role: "user" }, [{ role: "assistant" }]]`。

修改方案：
依据 `component.isInitialized` 标识，在首次生成代码时跳过携带上下文信息。